### PR TITLE
default select option with empty string value

### DIFF
--- a/www/App_Data/template/common/form/showform/select.html
+++ b/www/App_Data/template/common/form/showform/select.html
@@ -1,5 +1,6 @@
 <select id="<~field>" name="item[<~field>]" class="form-control <~class_control>">
   <~option0 if="is_option0" inline><option value="0">- select -</option></~option0>
+  <~option0e if="is_option0e" inline><option value="">- select -</option></~option0e>
   <~select_options select="value">
 </select>
 <~./help_block if="help_text">


### PR DESCRIPTION
For example, if I need to reset value to NULL in DB, instead of putting "0"