### PR TITLE
Allow layout override for PJAX

### DIFF
--- a/www/App_Code/fw/FW.vb
+++ b/www/App_Code/fw/FW.vb
@@ -778,15 +778,16 @@ Public Class FW
         End If
 
         Me.resp.CacheControl = cache_control
+                
+        Dim layout As String = ""
         If format = "pjax" Then
-            Dim layout As String = G("PAGE_LAYOUT_PJAX")
-            parser(bdir, layout, hf)
-
+            layout = G("PAGE_LAYOUT_PJAX")
         Else
-            Dim layout As String = G("PAGE_LAYOUT")
-            If hf.ContainsKey("_layout") Then layout = hf("_layout")
-            parser(bdir, layout, hf)
+            layout = G("PAGE_LAYOUT")
         End If
+
+        If hf.ContainsKey("_layout") Then layout = hf("_layout")
+        parser(bdir, layout, hf)
 
     End Sub
 


### PR DESCRIPTION
Sometimes I just need to return raw-html, for example, `options` for `select` and replace some `select` element.
I.e. I need a template containing only <~main noescape>

Is this modification a good solution to use something like this:

```
Public Function SomeAjaxAction() As Hashtable
...
Return New Hashtable From {
            {"_layout", "/layout_pjax_main_noescape.html"},
            {"main", html_options}
        }

```

or should I directly use `FW.resp.Write(html_options)` from the Action function/sub?