### PR TITLE
Less height sidebar

### DIFF
--- a/www/assets/css/site.css
+++ b/www/assets/css/site.css
@@ -337,7 +337,7 @@ div.jGrowl div.jGrowl-notification
         position: -webkit-sticky;
         position: sticky;
         /*top: 48px;*/
-        height: calc(100vh - 48px);
+        height: calc(100vh - 88px);
         padding-top: .5rem;
         overflow-x: hidden;
         overflow-y: auto;


### PR DESCRIPTION
We need less height for the sidebar, because the "Logoff" becomes inaccessible in case of  two line footer.
**hr** overlaps it.

![image](https://user-images.githubusercontent.com/35847544/57707256-fbd50580-766f-11e9-9d6c-3cfb20a49b4a.png)
